### PR TITLE
feat(the-race): swap standings for a filterable log card

### DIFF
--- a/workspaces/web/app/components/ui/tabs.tsx
+++ b/workspaces/web/app/components/ui/tabs.tsx
@@ -26,6 +26,7 @@ const tabsListVariants = cva(
 			variant: {
 				default: 'bg-muted',
 				line: 'gap-1 bg-transparent',
+				ghost: 'bg-transparent p-0 ring-0',
 				'the-race-bg':
 					'bg-linear-to-b from-[oklch(0.18_0.01_50)] to-[oklch(0.24_0.01_50)] ring-1 ring-white/10',
 				'the-race-red': 'bg-linear-to-b from-the-race-red-from to-the-race-red-to',

--- a/workspaces/web/app/games/the-race/components/CarBadge.tsx
+++ b/workspaces/web/app/games/the-race/components/CarBadge.tsx
@@ -6,7 +6,7 @@ export function CarBadge({ liveryId, className }: { liveryId: number; className?
 	return (
 		<span
 			className={cn(
-				'flex min-w-8 items-center justify-center rounded text-sm leading-7 font-bold',
+				'flex min-w-8 items-center justify-center rounded-lg py-1 text-sm font-bold',
 				className
 			)}
 			style={{

--- a/workspaces/web/app/games/the-race/components/CarInfoCard.tsx
+++ b/workspaces/web/app/games/the-race/components/CarInfoCard.tsx
@@ -1,0 +1,30 @@
+import { Layers } from 'lucide-react';
+import { cn } from '~/lib/utils';
+import { CarBadge } from './CarBadge';
+
+interface CarInfoCardProps {
+	liveryId: number;
+	/** Cards the car has left in hand. */
+	handSize: number;
+	className?: string;
+}
+
+/** A small card surfacing a car's number and how many cards it has left in hand.
+ *  Rendered above each car on the track (below for the top row) and below the
+ *  car piece in the hand view. Positioning is left to the caller via `className`. */
+export function CarInfoCard({ liveryId, handSize, className }: CarInfoCardProps) {
+	return (
+		<div
+			className={cn(
+				'flex items-center gap-2 rounded-xl border border-white/15 bg-linear-to-b from-the-race-bg-from to-the-race-bg-to p-2.5 shadow-md backdrop-blur-sm',
+				className
+			)}
+		>
+			<CarBadge liveryId={liveryId} className="h-6 text-white" />
+			<span className="flex items-center gap-1 pr-0.5 text-sm font-bold text-white/90">
+				<Layers className="size-3.5 opacity-70" />
+				{handSize}
+			</span>
+		</div>
+	);
+}

--- a/workspaces/web/app/games/the-race/components/ChampionsBanner.tsx
+++ b/workspaces/web/app/games/the-race/components/ChampionsBanner.tsx
@@ -26,7 +26,7 @@ export function ChampionsBanner({ driversChampion, constructorsChampion, carLive
 					<span className="text-[10px] tracking-wider text-the-race-white-to uppercase">
 						Drivers&rsquo; Champion
 					</span>
-					<span className="truncate text-lg font-bold">{driverLiv.driverName}</span>
+					<span className="truncate text-lg font-bold">Car #{driverLiv.number}</span>
 					<span className="truncate text-xs text-the-race-white-to">
 						{driverLiv.teamName} · {driversChampion.points} pts
 					</span>

--- a/workspaces/web/app/games/the-race/components/ChampionshipStandings.tsx
+++ b/workspaces/web/app/games/the-race/components/ChampionshipStandings.tsx
@@ -50,7 +50,7 @@ export function DriversChampionship({ standings, myCarIds, crownLeader }: Driver
 							<div className="flex min-w-0 flex-col">
 								<div className="flex items-center gap-2">
 									<span className={cn('truncate', isMine && 'font-semibold')}>
-										{liv.driverName}
+										Car #{liv.number}
 									</span>
 									{isMine && <YouChip />}
 								</div>

--- a/workspaces/web/app/games/the-race/components/DriverOfTheDayBadge.tsx
+++ b/workspaces/web/app/games/the-race/components/DriverOfTheDayBadge.tsx
@@ -19,7 +19,7 @@ export function DriverOfTheDayBadge({ dotd, carLiveries }: Props) {
 				<span className="text-[10px] tracking-wider text-the-race-accent uppercase">
 					Driver of the Day
 				</span>
-				<span className="truncate font-semibold">{liv.driverName}</span>
+				<span className="truncate font-semibold">Car #{liv.number}</span>
 			</div>
 			<CarBadge liveryId={liv.id} className="ml-auto" />
 			<span className="text-sm font-semibold tabular-nums">+{dotd.placesGained}</span>

--- a/workspaces/web/app/games/the-race/components/GameLog.tsx
+++ b/workspaces/web/app/games/the-race/components/GameLog.tsx
@@ -33,7 +33,7 @@ function Line({ children }: { children: ReactNode }) {
 
 // Render an event's structured data into log row(s). All copy lives here — events
 // carry data only — so wording changes never touch the server or the event shape.
-function renderEvent(event: RaceEvent, liveryOf: (carId: number) => number): ReactNode {
+export function renderEvent(event: RaceEvent, liveryOf: (carId: number) => number): ReactNode {
 	const badge = (carId: number) => <CarBadge liveryId={liveryOf(carId)} />;
 	const cards = (cs: Card[]) => cs.map((c) => <PlayingCard key={c.id} card={c} size="xs" />);
 
@@ -148,7 +148,10 @@ export function GameLog({ log, cars, className }: GameLogProps) {
 	const recent = [...filtered].reverse().slice(0, 20);
 
 	return (
-		<UICard variant="the-race-bg" className={cn('h-60 min-w-60 pb-0', className)}>
+		<UICard
+			variant="the-race-bg"
+			className={cn('h-[clamp(10rem,24dvh,15rem)] min-w-60 pb-0', className)}
+		>
 			<CardHeader className="flex items-center justify-between">
 				<span className="text-lg font-bold tracking-wide uppercase">Log</span>
 				<DropdownMenu>
@@ -171,7 +174,7 @@ export function GameLog({ log, cars, className }: GameLogProps) {
 							{cars.map((c) => (
 								<DropdownMenuRadioItem key={c.id} value={String(c.id)} className="gap-2">
 									<CarBadge liveryId={c.liveryId} />
-									<span className="whitespace-nowrap">{livery(c.liveryId).driverName}</span>
+									<span className="whitespace-nowrap">Car #{livery(c.liveryId).number}</span>
 								</DropdownMenuRadioItem>
 							))}
 						</DropdownMenuRadioGroup>

--- a/workspaces/web/app/games/the-race/components/HandView.tsx
+++ b/workspaces/web/app/games/the-race/components/HandView.tsx
@@ -3,7 +3,8 @@ import { isExtendCard } from '../engine/cards';
 import { PlayingCard } from './PlayingCard';
 import { Card as CardComponent, CardContent } from '~/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
-import { livery } from '../engine/liveries';
+import { cn } from '~/lib/utils';
+import { CarInfoCard } from './CarInfoCard';
 import { CarPiece } from './CarPiece';
 import { RaceBorderBeam } from './RaceBorderBeam';
 
@@ -74,13 +75,24 @@ export function HandView({
 			className="w-full"
 		>
 			{myCars.length > 1 && (
-				<TabsList variant="the-race-bg" className="space-x-1 p-1">
+				<TabsList variant="ghost" className="space-x-1">
 					{myCars.map((car) => {
 						const isTabActive = activeCarIds?.includes(car.id);
+						const isSelected = car.id === selectedCarId;
 						return (
-							<RaceBorderBeam active={isTabActive}>
-								<TabsTrigger key={car.id} value={String(car.id)} className="px-3 py-1.5">
-									#{livery(car.liveryId).number}
+							<RaceBorderBeam key={car.id} active={isTabActive}>
+								<TabsTrigger
+									value={String(car.id)}
+									className="h-auto border-0 bg-transparent p-0 data-active:bg-transparent dark:data-active:border-0 dark:data-active:bg-transparent"
+								>
+									<CarInfoCard
+										liveryId={car.liveryId}
+										handSize={car.handSize}
+										className={cn(
+											'transition-opacity',
+											isSelected ? 'ring-1 ring-white/0' : 'brightness-70'
+										)}
+									/>
 								</TabsTrigger>
 							</RaceBorderBeam>
 						);
@@ -90,15 +102,16 @@ export function HandView({
 			{myCars.map((car) => {
 				return (
 					<TabsContent key={car.id} value={String(car.id)}>
-						<CardComponent variant="the-race-bg" className="relative h-74 p-0">
-							<CardContent className="flex p-0">
-								<div className="top-0 bottom-0 flex w-full flex-1 items-center justify-center px-10 py-25 pr-0">
-									<CarPiece
-										liveryId={car.liveryId}
-										className="w-40 -rotate-90 drop-shadow-[0_0_40px_rgba(255,255,255,0.7)]"
-									/>
+						<CardComponent
+							variant="the-race-bg"
+							className="relative h-[clamp(13rem,28dvh,18.5rem)] p-0"
+						>
+							<CardContent className="flex h-full p-0">
+								<div className="flex w-full flex-1 flex-col items-center justify-center gap-6 px-10 pr-0">
+									<CarPiece liveryId={car.liveryId} className="w-40 -rotate-90" />
+									<CarInfoCard liveryId={car.liveryId} handSize={car.handSize} />
 								</div>
-								<div className="flex h-74 flex-5 scrollbar-none flex-wrap items-center justify-center gap-4 overflow-y-scroll px-15 py-15">
+								<div className="flex h-full flex-5 scrollbar-none flex-wrap items-center justify-center gap-4 overflow-y-scroll px-12 py-6">
 									{renderCards(car.hand ?? [])}
 								</div>
 							</CardContent>

--- a/workspaces/web/app/games/the-race/components/LogView.tsx
+++ b/workspaces/web/app/games/the-race/components/LogView.tsx
@@ -1,0 +1,87 @@
+import { Fragment, useState } from 'react';
+import { ChevronDownIcon } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '~/components/ui/card';
+import { Button } from '~/components/ui/button';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger
+} from '~/components/ui/dropdown-menu';
+import type { PublicGameState } from '../engine/types';
+import { eventCarIds } from '../engine/events';
+import { livery } from '../engine/liveries';
+import { TheRaceLogo } from './TheRaceLogo';
+import { HowToPlay } from './HowToPlay';
+import { CarBadge } from './CarBadge';
+import { renderEvent } from './GameLog';
+
+interface LogViewProps {
+	state: PublicGameState;
+}
+
+const ALL = 'all';
+
+// The logo-headed card alongside the track: the same header as the standings used
+// to carry (logo + how-to-play), with the running game log as its body.
+export function LogView({ state }: LogViewProps) {
+	const [filterCarId, setFilterCarId] = useState<number | null>(null);
+
+	const liveryById = new Map(state.cars.map((c) => [c.id, c.liveryId]));
+	const liveryOf = (carId: number) => liveryById.get(carId) ?? carId;
+
+	// System events (no associated car) always show; everything else respects the filter.
+	const filtered =
+		filterCarId === null
+			? state.log
+			: state.log.filter((e) => {
+					const ids = eventCarIds(e);
+					return ids.length === 0 || ids.includes(filterCarId);
+				});
+	const recent = [...filtered].reverse().slice(0, 20);
+
+	return (
+		<Card variant="the-race-bg" className="h-[clamp(13rem,28dvh,20rem)] w-100 pb-0">
+			<CardHeader className="flex items-center justify-between">
+				<TheRaceLogo />
+				<div className="flex items-center gap-2">
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button variant="the-race-bg" size="sm" className="flex h-9 gap-2 p-1 pr-2">
+								{filterCarId === null ? (
+									<span className="pl-2">All</span>
+								) : (
+									<CarBadge liveryId={liveryOf(filterCarId)} />
+								)}
+								<ChevronDownIcon />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" variant="the-race-bg" className="w-auto">
+							<DropdownMenuRadioGroup
+								value={filterCarId === null ? ALL : String(filterCarId)}
+								onValueChange={(v) => setFilterCarId(v === ALL ? null : Number(v))}
+							>
+								<DropdownMenuRadioItem value={ALL}>All cars</DropdownMenuRadioItem>
+								{state.cars.map((c) => (
+									<DropdownMenuRadioItem key={c.id} value={String(c.id)} className="gap-2">
+										<CarBadge liveryId={c.liveryId} />
+										<span className="whitespace-nowrap">Car #{livery(c.liveryId).number}</span>
+									</DropdownMenuRadioItem>
+								))}
+							</DropdownMenuRadioGroup>
+						</DropdownMenuContent>
+					</DropdownMenu>
+					<HowToPlay />
+				</div>
+			</CardHeader>
+			<CardContent className="scrollbar-none overflow-y-scroll">
+				<ul className="flex flex-col gap-4 pt-2">
+					{recent.map((e, i) => (
+						<Fragment key={i}>{renderEvent(e, liveryOf)}</Fragment>
+					))}
+				</ul>
+			</CardContent>
+		</Card>
+	);
+}

--- a/workspaces/web/app/games/the-race/components/PlayedCardStack.tsx
+++ b/workspaces/web/app/games/the-race/components/PlayedCardStack.tsx
@@ -74,7 +74,7 @@ export function PlayedCardStack({ cards, emphasized }: PlayedCardStackProps) {
 	// piece); the inner motion element owns the animated transform (Framer manages
 	// `transform`, so the two must not share an element or one clobbers the other).
 	return (
-		<div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+		<div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center">
 			<motion.div
 				// A drop-shadow filter (not box-shadow) so the shadow follows each card's
 				// rounded silhouette and lifts it off the car. Safe to set via class — the

--- a/workspaces/web/app/games/the-race/components/RaceClassification.tsx
+++ b/workspaces/web/app/games/the-race/components/RaceClassification.tsx
@@ -37,7 +37,7 @@ export function RaceClassification({ scores, cars, players, carLiveries, myCarId
 						<CarBadge liveryId={liv.id} />
 						<div className="flex min-w-0 flex-col">
 							<div className="flex items-center gap-2">
-								<span className={cn('truncate', isMine && 'font-semibold')}>{liv.driverName}</span>
+								<span className={cn('truncate', isMine && 'font-semibold')}>Car #{liv.number}</span>
 								{isMine && <YouChip />}
 							</div>
 							<span className="truncate text-xs text-the-race-white-to">

--- a/workspaces/web/app/games/the-race/components/RacePodium.tsx
+++ b/workspaces/web/app/games/the-race/components/RacePodium.tsx
@@ -32,7 +32,7 @@ export function RacePodium({ scores, carLiveries, myCarIds }: Props) {
 						<CarBadge liveryId={liv.id} className="size-9 text-base" />
 						{isMine && <YouChip className="mt-1" />}
 						<p className={cn('mt-1 text-center text-sm leading-tight', isWinner && 'font-bold')}>
-							{liv.driverName}
+							Car #{liv.number}
 						</p>
 						<p className="text-center text-xs text-the-race-white-to">{liv.teamName}</p>
 						<p className="mt-0.5 text-xs font-semibold">{score.points} pts</p>

--- a/workspaces/web/app/games/the-race/components/RaceView.tsx
+++ b/workspaces/web/app/games/the-race/components/RaceView.tsx
@@ -1,8 +1,9 @@
 import { TrackView } from './TrackView';
 import { HandView } from './HandView';
 import { ActionView } from './ActionView';
-import { StandingsView } from './StandingsView';
-import { GameLog } from './GameLog';
+import { LogView } from './LogView';
+import { TurnBanner } from './TurnBanner';
+import { turnPrompt } from '../engine/raceView';
 import type { RaceSession } from '../hooks/useRaceSession';
 
 interface RaceViewProps {
@@ -27,28 +28,27 @@ export function RaceView({ session }: RaceViewProps) {
 
 	if (!state || !view) return null;
 
+	// The screen is a fixed h-dvh column that never scrolls: the standings/log
+	// row and the hand row scale with viewport height (clamped in each
+	// component), and the track absorbs whatever is left — zooming its lanes
+	// down to fit — so the hand is never pushed off the bottom.
 	return (
-		<div className="flex h-dvh scrollbar-none flex-col gap-5 overflow-y-scroll p-5">
-			<div className="flex justify-between gap-5">
-				<StandingsView
-					state={state}
-					activeCarIds={view.activeCarIds}
-					pendingChallenge={state.pendingChallenge}
-					myCarIds={view.myCarIds}
-					reveal={reveal}
-				/>
-				<GameLog log={state.log} cars={state.cars} className="w-70" />
+		<div className="flex h-dvh flex-col gap-5 overflow-hidden p-5">
+			<div className="flex shrink-0 justify-between gap-5">
+				<LogView state={state} />
+				<TurnBanner prompt={turnPrompt(state, view.myCarIds)} className="min-w-0 flex-1" />
 			</div>
-			<div className="flex flex-1 items-center">
+			<div className="flex min-h-48 flex-1 flex-col overflow-hidden">
 				<TrackView
 					state={state}
 					holdAtStart={view.holdAtStart}
 					reveal={reveal}
 					challenge={challengeReveal}
 					gridReveal={gridReveal}
+					className="h-full"
 				/>
 			</div>
-			<div className="flex items-end gap-5">
+			<div className="flex shrink-0 items-end gap-5">
 				<HandView
 					selectedMainId={view.mainCardId}
 					pairRedlineId={view.pairCardId}
@@ -62,7 +62,7 @@ export function RaceView({ session }: RaceViewProps) {
 				/>
 
 				<ActionView
-					className="h-74 min-w-70"
+					className="h-[clamp(13rem,28dvh,18.5rem)] min-w-70"
 					actions={
 						view.isQualifying
 							? [{ label: 'Qualify', onClick: qualify, disabled: !view.canQualify }]

--- a/workspaces/web/app/games/the-race/components/StandingsView.tsx
+++ b/workspaces/web/app/games/the-race/components/StandingsView.tsx
@@ -34,7 +34,7 @@ export function StandingsView({
 	const qualifiedCarIds = new Set(state.qualifiedCarIds ?? []);
 
 	return (
-		<Card variant="the-race-bg" className="h-80 w-100 pb-0">
+		<Card variant="the-race-bg" className="h-[clamp(13rem,28dvh,20rem)] w-100 pb-0">
 			<CardHeader className="flex items-center justify-between">
 				<TheRaceLogo />
 				<HowToPlay />
@@ -102,7 +102,7 @@ export function StandingsView({
 									{isYourTurn && <YouChip className="absolute top-0 left-8 -translate-y-1/4" />}
 									<span className="w-5 font-extrabold">{rank + 1}</span>
 									<CarBadge liveryId={car.liveryId} />
-									<span className="whitespace-nowrap">{liv.driverName ?? '?'}</span>
+									<span className="whitespace-nowrap">Car #{liv.number}</span>
 									<div className="flex w-full items-center justify-end gap-2 py-2 font-bold">
 										{isChallenger && <span className="text-sm">ATK</span>}
 										{isDefender && <span className="text-sm">DEF</span>}

--- a/workspaces/web/app/games/the-race/components/TrackView.tsx
+++ b/workspaces/web/app/games/the-race/components/TrackView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { carsOnClock } from '../engine/raceView';
 import type { Card, PublicGameState } from '../engine/types';
@@ -10,6 +10,7 @@ import {
 	type RaceReveal
 } from '../hooks/useRacePresentation';
 import { cn } from '~/lib/utils';
+import { CarInfoCard } from './CarInfoCard';
 import { CarPiece } from './CarPiece';
 import { PlayedCardStack } from './PlayedCardStack';
 
@@ -49,6 +50,9 @@ export function TrackView({
 	gridReveal,
 	className
 }: TrackViewProps) {
+	// While qualifying, cars sit in the start/qualifying lane — the info card has no
+	// position to annotate yet, so keep it hidden until the grid is set.
+	const isQualifying = state.phase === 'qualifying';
 	const maxPosition = state.cars.length > 0 ? Math.max(...state.cars.map((c) => c.position)) : 0;
 	const tileCount = Math.max(20, maxPosition + 2);
 	const laneCount = Math.max(1, state.cars.length);
@@ -80,6 +84,28 @@ export function TrackView({
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const targetScrollLeft = useRef(0);
 	const rafRef = useRef<number | null>(null);
+
+	// Scale the track down (never up) to fit the height the layout gives it, so
+	// no lane is ever cut off. CSS zoom (not transform) so layout — and the
+	// horizontal scroll range — shrinks with it; car positions and card overlays
+	// live in the zoomed coordinate space and need no adjustment.
+	const [scale, setScale] = useState(1);
+	useEffect(() => {
+		const el = scrollRef.current;
+		if (!el) return;
+		const update = () => {
+			const styles = getComputedStyle(el);
+			const padding = parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom);
+			const available = el.clientHeight - padding;
+			// A degenerate measurement (row collapsed to nothing mid-layout) keeps
+			// the previous scale — snapping to full size would be the worst fit.
+			setScale((prev) => (available > 0 ? Math.min(1, available / trackHeight) : prev));
+		};
+		update();
+		const ro = new ResizeObserver(update);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [trackHeight]);
 	useEffect(() => {
 		const el = scrollRef.current;
 		if (!el) return;
@@ -122,9 +148,12 @@ export function TrackView({
 			// out far enough that the cards — which overflow their lane by ~half a card —
 			// stay fully visible. The inner `w-max` wrapper is the cars' positioning
 			// context, so they still align to the tiles despite the padding.
-			className={cn('relative scrollbar-none overflow-x-scroll overflow-y-visible py-6', className)}
+			className={cn(
+				'relative flex scrollbar-none flex-col justify-center overflow-x-scroll overflow-y-visible py-6',
+				className
+			)}
 		>
-			<div className="relative w-max">
+			<div className="relative w-max" style={{ zoom: scale }}>
 				<div className="flex items-center" style={{ height: trackHeight }}>
 					{Array.from({ length: tileCount }).map((_, i) => {
 						const dimmed = focusActive && !highlightedTiles.has(i);
@@ -205,9 +234,11 @@ export function TrackView({
 								? REVEAL_MOVE_DELAY_MS / 1000
 								: 0;
 						return (
+							// No `layout` prop here: every real move animates through x/y below,
+							// and layout's re-measured boxes disagree with the zoomed track's
+							// coordinate space, re-animating cars on unrelated state updates.
 							<motion.div
 								key={car.id}
-								layout
 								initial={false}
 								animate={{
 									x: holdAtStart ? 0 : (car.position + 1) * TILE_WIDTH,
@@ -220,6 +251,29 @@ export function TrackView({
 									carDimmed && 'brightness-45'
 								)}
 							>
+								{/* Info card riding above each car (below for the top row, so it
+								    never clips past the track's top edge). Hidden through qualifying;
+								    during the grid reveal it fades in just as its car settles onto the
+								    grid — one beat behind that car's staggered pull-out. */}
+								{!isQualifying && (
+									<motion.div
+										initial={{ opacity: 0 }}
+										animate={{ opacity: 1 }}
+										transition={{
+											duration: 0.3,
+											delay: gridReveal
+												? ((gridRank.get(car.id) ?? 0) * GRID_REVEAL_STAGGER_MS + CAR_MOVE_MS) /
+													1000
+												: 0
+										}}
+										className={cn(
+											'pointer-events-none absolute left-1/2 z-20 -translate-x-1/2',
+											lane === 0 ? 'top-full mt-1' : 'bottom-full mb-1'
+										)}
+									>
+										<CarInfoCard liveryId={car.liveryId} handSize={car.handSize} />
+									</motion.div>
+								)}
 								{playedCards && <PlayedCardStack cards={playedCards} emphasized={emphasized} />}
 								<CarPiece className="w-36" liveryId={car.liveryId} />
 							</motion.div>

--- a/workspaces/web/app/games/the-race/components/TurnBanner.tsx
+++ b/workspaces/web/app/games/the-race/components/TurnBanner.tsx
@@ -1,0 +1,49 @@
+import { AnimatePresence, motion } from 'framer-motion';
+import { cn } from '~/lib/utils';
+import type { TurnPrompt } from '../engine/raceView';
+
+interface TurnBannerProps {
+	prompt: TurnPrompt;
+	className?: string;
+}
+
+// The headline between the standings and the log: what the viewer should be
+// doing right now, or what they're waiting on. Copy comes from the pure
+// turnPrompt projection; this only renders (and cross-fades) it.
+export function TurnBanner({ prompt, className }: TurnBannerProps) {
+	return (
+		<div
+			className={cn(
+				'flex flex-col items-center justify-center gap-1.5 px-4 text-center',
+				className
+			)}
+		>
+			<AnimatePresence mode="wait">
+				<motion.span
+					key={prompt.title}
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					exit={{ opacity: 0, y: -8 }}
+					transition={{ duration: 0.2, ease: 'easeInOut' }}
+					className="text-3xl font-extrabold tracking-wide text-the-race-white-from uppercase"
+				>
+					{prompt.title}
+				</motion.span>
+			</AnimatePresence>
+			<AnimatePresence mode="wait">
+				{prompt.subtitle && (
+					<motion.span
+						key={prompt.subtitle}
+						initial={{ opacity: 0, y: 8 }}
+						animate={{ opacity: 1, y: 0 }}
+						exit={{ opacity: 0, y: -8 }}
+						transition={{ duration: 0.2, ease: 'easeInOut' }}
+						className="text-[15px] text-white/60"
+					>
+						{prompt.subtitle}
+					</motion.span>
+				)}
+			</AnimatePresence>
+		</div>
+	);
+}

--- a/workspaces/web/app/games/the-race/engine/raceView.test.ts
+++ b/workspaces/web/app/games/the-race/engine/raceView.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { selectRaceView, carsOnClock, autoFocusCarId } from './raceView';
+import { selectRaceView, carsOnClock, autoFocusCarId, turnPrompt } from './raceView';
 import type { Card, PublicCarState, PublicGameState } from './types';
 import type { SelectionState } from './types';
-import { liveryTeamId } from './liveries';
+import { livery, liveryTeamId } from './liveries';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -333,5 +333,100 @@ describe('selectRaceView selection view', () => {
 		// Open solo turn (car 0 has a free space ahead), Redline in hand, main selected.
 		const open = makeState({ cars: [car(0, 0, [reg(1), redline]), car(1, 5, [reg(2)])] });
 		expect(selectRaceView(open, { 0: ['gears:1'] }, 'p1', 0).canPairRedline).toBe(false);
+	});
+});
+
+// ─── Turn prompt ──────────────────────────────────────────────────────────────
+
+describe('turnPrompt', () => {
+	const label = (carId: number) => `Car #${livery(carId).number}`;
+
+	it('qualifying: prompts the viewer while their car is still to lock in', () => {
+		const state = makeState({ phase: 'qualifying' });
+		const p = turnPrompt(state, [0]);
+		expect(p.title).toBe('Qualifying');
+		expect(p.subtitle).toMatch(/pick a card/i);
+	});
+
+	it('qualifying: prompts per-car when both of the viewer cars are pending', () => {
+		const state = makeState({
+			phase: 'qualifying',
+			players: [{ id: 'p1', name: 'Alice', carIds: [0, 1], isHost: true, connected: true }]
+		});
+		expect(turnPrompt(state, [0, 1]).subtitle).toMatch(/each of your cars/i);
+	});
+
+	it('qualifying: waits once the viewer car has locked in', () => {
+		const state = makeState({ phase: 'qualifying', pendingThisRound: [1] });
+		expect(turnPrompt(state, [0]).subtitle).toMatch(/waiting/i);
+	});
+
+	it('race: tells the viewer it is their turn when their car is on the clock', () => {
+		// Default state: car 0 (pos 2) is the lowest-position pending car.
+		const p = turnPrompt(makeState(), [0]);
+		expect(p.title).toBe('Your turn');
+	});
+
+	it('race: labels the car on the clock when waiting', () => {
+		const p = turnPrompt(makeState(), [1]);
+		expect(p.title).toBe(`${label(0)}'s turn`);
+		expect(p.subtitle).toMatch(/waiting/i);
+	});
+
+	it('challenge: prompts the uncommitted challenger to attack the defender', () => {
+		const state = makeState({
+			pendingChallenge: {
+				challengerCarId: 0,
+				defenderCarId: 1,
+				challengerCommitted: false,
+				defenderCommitted: false
+			}
+		});
+		const p = turnPrompt(state, [0]);
+		expect(p.title).toBe('Attack!');
+		expect(p.subtitle).toContain(label(1));
+	});
+
+	it('challenge: prompts the uncommitted defender to hold off the challenger', () => {
+		const state = makeState({
+			pendingChallenge: {
+				challengerCarId: 0,
+				defenderCarId: 1,
+				challengerCommitted: false,
+				defenderCommitted: false
+			}
+		});
+		const p = turnPrompt(state, [1]);
+		expect(p.title).toBe('Defend!');
+		expect(p.subtitle).toContain(label(0));
+	});
+
+	it('challenge: a committed side waits on the other', () => {
+		const state = makeState({
+			pendingChallenge: {
+				challengerCarId: 0,
+				defenderCarId: 1,
+				challengerCommitted: true,
+				defenderCommitted: false
+			}
+		});
+		const p = turnPrompt(state, [0]);
+		expect(p.title).toBe('Challenge');
+		expect(p.subtitle).toContain(label(1));
+	});
+
+	it('challenge: an uninvolved viewer sees who is duelling', () => {
+		const state = makeState({
+			pendingChallenge: {
+				challengerCarId: 0,
+				defenderCarId: 1,
+				challengerCommitted: false,
+				defenderCommitted: false
+			}
+		});
+		const p = turnPrompt(state, []);
+		expect(p.title).toBe('Challenge!');
+		expect(p.subtitle).toContain(label(0));
+		expect(p.subtitle).toContain(label(1));
 	});
 });

--- a/workspaces/web/app/games/the-race/engine/raceView.ts
+++ b/workspaces/web/app/games/the-race/engine/raceView.ts
@@ -11,6 +11,7 @@
 
 import type { Phase, PublicGameState, RaceView, SelectionState } from './types';
 import { carLegalMoves } from './legalMoves';
+import { livery } from './liveries';
 import { canPairRedline, getSelection, hasMainSelected } from './selection';
 
 /**
@@ -38,6 +39,83 @@ export function carsOnClock(state: {
 		}
 	}
 	return new Set();
+}
+
+// ─── Turn prompt ──────────────────────────────────────────────────────────────
+
+/** Headline + supporting line telling the viewer what to do (or wait for). */
+export interface TurnPrompt {
+	title: string;
+	subtitle: string;
+}
+
+/**
+ * What the viewer should be doing right now, as a title/subtitle pair for the
+ * banner between the standings and the log. Viewer-centric: the same state
+ * yields "Your turn" for the car on the clock and "Car #<n>'s turn" for
+ * everyone else. Cars are labelled by their livery number, matching the badges.
+ */
+export function turnPrompt(
+	state: Pick<PublicGameState, 'phase' | 'pendingThisRound' | 'pendingChallenge'> & {
+		cars: readonly { id: number; position: number; liveryId: number }[];
+	},
+	myCarIds: readonly number[]
+): TurnPrompt {
+	const mine = new Set(myCarIds);
+	const carLabel = (carId: number) => {
+		const car = state.cars.find((c) => c.id === carId);
+		return car ? `Car #${livery(car.liveryId).number}` : `Car #${carId}`;
+	};
+
+	if (state.phase === 'qualifying') {
+		// During qualifying pendingThisRound is the set of cars yet to lock in.
+		const myPending = state.pendingThisRound.filter((id) => mine.has(id));
+		if (myPending.length > 1)
+			return { title: 'Qualifying', subtitle: 'Pick a qualifying card for each of your cars' };
+		if (myPending.length === 1)
+			return { title: 'Qualifying', subtitle: 'Pick a card to set your spot on the grid' };
+		return { title: 'Qualifying', subtitle: 'Waiting for the other drivers to lock in…' };
+	}
+
+	const pc = state.pendingChallenge;
+	if (pc) {
+		const amChallenger = mine.has(pc.challengerCarId);
+		const amDefender = mine.has(pc.defenderCarId);
+		if (amChallenger && !pc.challengerCommitted)
+			return {
+				title: 'Attack!',
+				subtitle: `Play your card(s) to attack ${carLabel(pc.defenderCarId)}`
+			};
+		if (amDefender && !pc.defenderCommitted)
+			return {
+				title: 'Defend!',
+				subtitle: `Play your card(s) to hold off ${carLabel(pc.challengerCarId)}`
+			};
+		if (amChallenger || amDefender) {
+			const waitingOn = amChallenger ? pc.defenderCarId : pc.challengerCarId;
+			return {
+				title: 'Challenge',
+				subtitle: `Waiting for ${carLabel(waitingOn)} to play their card(s)…`
+			};
+		}
+		return {
+			title: 'Challenge!',
+			subtitle: `${carLabel(pc.challengerCarId)} attacks ${carLabel(pc.defenderCarId)}`
+		};
+	}
+
+	if (state.phase === 'race') {
+		const [next] = carsOnClock(state);
+		if (next === undefined) return { title: 'Race', subtitle: 'Starting the next round…' };
+		if (mine.has(next))
+			return {
+				title: 'Your turn',
+				subtitle: 'Extend with a 1–3 card, or discard to hold position'
+			};
+		return { title: `${carLabel(next)}'s turn`, subtitle: 'Waiting for them to play a card…' };
+	}
+
+	return { title: 'The Race', subtitle: '' };
 }
 
 /**


### PR DESCRIPTION
Replace the standings panel beside the track with a logo-headed LogView showing the running game log (car filter + how-to-play in the header). Label cars by livery number (Car #N) everywhere driver names were shown, add a per-car CarInfoCard on the track that fades in after the qualifying grid reveal, and raise played-card stacks above it on the z-axis.