### PR TITLE
feat(photography): add minimal loading state to prevent layout shift

### DIFF
--- a/workspaces/web/app/components/PhotoFrame.tsx
+++ b/workspaces/web/app/components/PhotoFrame.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '~/lib/utils';
+import { getImageUrl } from '~/utils';
+
+export type Photo = { key: string; width: number; height: number };
+
+export function PhotoFrame({ image }: { image: Photo }) {
+	const ref = useRef<HTMLImageElement>(null);
+	const [loaded, setLoaded] = useState(false);
+
+	// Images that are already cached can finish loading before React attaches
+	// the onLoad handler, so reconcile against the element's complete flag.
+	useEffect(() => {
+		if (ref.current?.complete) {
+			setLoaded(true);
+		}
+	}, []);
+
+	return (
+		<div
+			className="relative self-center overflow-hidden"
+			style={{ aspectRatio: `${image.width} / ${image.height}` }}
+		>
+			<div
+				className={cn(
+					'absolute inset-0 bg-neutral-100 transition-opacity duration-700 ease-out',
+					loaded ? 'opacity-0' : 'animate-pulse opacity-100'
+				)}
+			/>
+			<img
+				ref={ref}
+				src={getImageUrl(image.key)}
+				alt="Photograph"
+				loading="lazy"
+				onLoad={() => setLoaded(true)}
+				className={cn(
+					'h-full w-full object-cover transition-opacity duration-700 ease-out',
+					loaded ? 'opacity-100' : 'opacity-0'
+				)}
+			/>
+		</div>
+	);
+}

--- a/workspaces/web/app/routes/photography.tsx
+++ b/workspaces/web/app/routes/photography.tsx
@@ -1,16 +1,37 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { env } from 'cloudflare:workers';
+import { PhotoFrame, type Photo } from '~/components/PhotoFrame';
 import { getImageUrl } from '../utils';
 
+// Resolve each photo's intrinsic dimensions up front so the grid can reserve
+// exact space and avoid layout shift as images stream in. The JSON metadata is
+// tiny and edge-cached by Cloudflare.
 const getPhotos = createServerFn().handler(async () => {
 	const objectData = await env.PHOTOS.list();
 
 	if (!objectData) {
-		return { images: [] as { key: string }[] };
+		return { images: [] as Photo[] };
 	}
 
-	return { images: objectData.objects.map(({ key }) => ({ key })) };
+	const images = await Promise.all(
+		objectData.objects.map(async ({ key }): Promise<Photo> => {
+			try {
+				const res = await fetch(`https://images.rafe.dev/cdn-cgi/image/format=json/${key}`);
+				if (res.ok) {
+					const data = (await res.json()) as { width?: number; height?: number };
+					if (data.width && data.height) {
+						return { key, width: data.width, height: data.height };
+					}
+				}
+			} catch {
+				// Fall back to a 3:2 frame if metadata can't be fetched.
+			}
+			return { key, width: 3, height: 2 };
+		})
+	);
+
+	return { images };
 });
 
 export const Route = createFileRoute('/photography')({
@@ -59,13 +80,7 @@ function PhotographyPage() {
 	return (
 		<div className="grid grid-cols-1 sm:grid-cols-2">
 			{images.map((image) => (
-				<img
-					key={image.key}
-					src={getImageUrl(image.key)}
-					alt="Photograph"
-					className="self-center object-contain"
-					loading="lazy"
-				/>
+				<PhotoFrame key={image.key} image={image} />
 			))}
 		</div>
 	);


### PR DESCRIPTION
Reserve each photo's intrinsic aspect ratio (resolved up front via the image CDN's format=json endpoint) so the grid no longer shifts as images stream in, and fade each image in over a subtle skeleton placeholder that matches the page's minimal style. Extract the per-image PhotoFrame into its own component.