### PR TITLE
feat(web): shmoney marketing page and shared SlashNav header

### DIFF
--- a/workspaces/web/app/components/shmoney/ScreenshotCarousel.tsx
+++ b/workspaces/web/app/components/shmoney/ScreenshotCarousel.tsx
@@ -183,14 +183,16 @@ export function ScreenshotCarousel() {
 				    peeking side slides toward the edges without dimming the arrows. */}
 				<div className="mask-x-from-[calc(100%-9rem)] mask-x-to-100%">
 					<CarouselContent className="pt-3 pb-14">
-						{SCREENSHOTS.map((shot, index) => (
+						{/* All slides load eagerly: the neighbors peek into view immediately
+						    and lazy loading makes them pop in mid-scroll. */}
+						{SCREENSHOTS.map((shot) => (
 							<CarouselItem key={shot.src} className="basis-3/4">
 								<img
 									src={shot.src}
 									alt={shot.alt}
 									width={1200}
 									height={800}
-									loading={index === 0 ? 'eager' : 'lazy'}
+									decoding="async"
 									draggable={false}
 									className="w-full rounded-xl border border-border select-none"
 								/>

--- a/workspaces/web/app/routes/about.tsx
+++ b/workspaces/web/app/routes/about.tsx
@@ -56,11 +56,21 @@ function AboutPage() {
 				</p>
 			</div>
 			<div className="flex flex-col gap-6">
-				<img src={getImageUrl('DSCF0740.JPEG')} alt="Yosemite Valley" />
+				<img src={getImageUrl('DSCF0740.JPEG')} alt="Yosemite Valley" width={6240} height={4160} />
 				<div className="grid grid-cols-3 gap-6">
-					<img src={getImageUrl('DSCF0770.JPEG')} alt="Yosemite Lodge" />
-					<img src={getImageUrl('DSCF0784.JPEG')} alt="Yosemite Abandoned Gas Station" />
-					<img src={getImageUrl('DSCF0754.JPEG')} alt="Half Dome and a Plane" />
+					<img src={getImageUrl('DSCF0770.JPEG')} alt="Yosemite Lodge" width={4160} height={6240} />
+					<img
+						src={getImageUrl('DSCF0784.JPEG')}
+						alt="Yosemite Abandoned Gas Station"
+						width={4160}
+						height={6240}
+					/>
+					<img
+						src={getImageUrl('DSCF0754.JPEG')}
+						alt="Half Dome and a Plane"
+						width={4160}
+						height={6240}
+					/>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- Adds a marketing page for shmoney at `/shmoney`: hero, screenshot carousel with autoplay and tween effects, feature grid, privacy ledger, and download CTAs, with the page split into components under `components/shmoney/` (shader gradient logo, wordmark, guilloche, carousel).
- Introduces a shared `SlashNav` breadcrumb component and adopts it site-wide: `rafe` links home and the slash separators are muted, matching the shmoney header. Page headers use `text-xl` with body copy at `text-base`.
- Links the shmoney project card on `/development` to the new page.
- Fixes image jank: carousel screenshots load eagerly since neighboring slides are visible immediately, and about page photos declare intrinsic dimensions to avoid layout shift.
- Chores: prettier formatting for config and shadcn files, lint ignores for generated files, new deps (embla carousel, shadergradient, three).

## Test plan
- `pnpm lint`, `tsc --noEmit`, and `pnpm test` pass in `workspaces/web`.
- Manually verified in the browser: /shmoney hero, carousel autoplay/drag, captions, and download buttons; SlashNav rendering on index, about, photography, and development; no layout shift on /about or /shmoney while images load.