### PR TITLE
feat(web): shared Link component with hover scale and blur

### DIFF
--- a/workspaces/web/app/components/Link.tsx
+++ b/workspaces/web/app/components/Link.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from 'react';
+import { cn } from '~/lib/utils';
+
+// inline-block so the transform applies; inline elements ignore scale
+const hoverEffect =
+	'inline-block transition-[transform,filter,color] duration-400 ease-out hover:scale-101 hover:blur-[1px]';
+
+export function Link({
+	plain = false,
+	className,
+	...props
+}: ComponentProps<'a'> & { plain?: boolean }) {
+	return <a className={cn(!plain && hoverEffect, className)} {...props} />;
+}

--- a/workspaces/web/app/components/shmoney/DownloadButton.tsx
+++ b/workspaces/web/app/components/shmoney/DownloadButton.tsx
@@ -1,15 +1,16 @@
 import { Download } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { Link } from '~/components/Link';
 import { Button } from '~/components/ui/button';
 import { LATEST_RELEASE_URL } from '~/components/shmoney/constants';
 
 export function DownloadButton({ children }: { children: ReactNode }) {
 	return (
 		<Button asChild size="lg" className="px-4">
-			<a href={LATEST_RELEASE_URL} target="_blank" rel="noreferrer">
+			<Link plain href={LATEST_RELEASE_URL} target="_blank" rel="noreferrer">
 				<Download data-icon="inline-start" className="size-4" />
 				{children}
-			</a>
+			</Link>
 		</Button>
 	);
 }

--- a/workspaces/web/app/routes/about.tsx
+++ b/workspaces/web/app/routes/about.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
 import { getImageUrl } from '../utils';
 
@@ -39,10 +40,10 @@ function AboutPage() {
 		<div className="flex flex-col gap-8 p-8 text-base text-black">
 			<div className="space-y-2">
 				<SlashNav className="text-xl font-medium">
-					<a href="/">rafe</a>
+					<Link href="/">rafe</Link>
 					about
 				</SlashNav>
-				<a href="mailto:rafe@rafe.dev">rafe@rafe.dev</a>
+				<Link href="mailto:rafe@rafe.dev">rafe@rafe.dev</Link>
 			</div>
 			<div className="flex max-w-4xl flex-col gap-8">
 				<p>

--- a/workspaces/web/app/routes/development.tsx
+++ b/workspaces/web/app/routes/development.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
 
 export const Route = createFileRoute('/development')({
@@ -29,7 +30,7 @@ function DevelopmentPage() {
 		<div className="flex flex-col items-center gap-8 p-8 text-base text-black">
 			<div className="w-full max-w-4xl space-y-2">
 				<SlashNav className="text-xl font-medium">
-					<a href="/">rafe</a>
+					<Link href="/">rafe</Link>
 					development
 				</SlashNav>
 			</div>
@@ -41,7 +42,8 @@ function DevelopmentPage() {
 			</div>
 			<div className="flex w-full max-w-4xl flex-col gap-6">
 				{projects.map((project) => (
-					<a
+					<Link
+						plain
 						key={project.name}
 						href={project.url}
 						target={project.url.startsWith('http') ? '_blank' : undefined}
@@ -58,7 +60,7 @@ function DevelopmentPage() {
 								<span key={topic}>#{topic}</span>
 							))}
 						</div>
-					</a>
+					</Link>
 				))}
 			</div>
 		</div>

--- a/workspaces/web/app/routes/index.tsx
+++ b/workspaces/web/app/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { env } from 'cloudflare:workers';
+import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
 import { getImageUrl } from '../utils';
 
@@ -68,9 +69,9 @@ function HomePage() {
 				}}
 			>
 				<SlashNav separatorClassName="text-inherit opacity-60">
-					<a href="/about">rafe</a>
-					<a href="/photography">photography</a>
-					<a href="/development">development</a>
+					<Link href="/about">rafe</Link>
+					<Link href="/photography">photography</Link>
+					<Link href="/development">development</Link>
 				</SlashNav>
 			</div>
 		</div>

--- a/workspaces/web/app/routes/photography.tsx
+++ b/workspaces/web/app/routes/photography.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 import { env } from 'cloudflare:workers';
 import { PhotoGallery } from '~/components/PhotoGallery';
+import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
 import { getImageUrl } from '../utils';
 
@@ -63,7 +64,7 @@ function PhotographyPage() {
 	return (
 		<div className="flex flex-col gap-8 p-8 text-black">
 			<SlashNav className="text-xl font-medium">
-				<a href="/">rafe</a>
+				<Link href="/">rafe</Link>
 				photography
 			</SlashNav>
 			<PhotoGallery imageKeys={imageKeys} />

--- a/workspaces/web/app/routes/shmoney.tsx
+++ b/workspaces/web/app/routes/shmoney.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Cpu, FileUp, Landmark, Mail, TrendingUp, Undo2 } from 'lucide-react';
 import { GITHUB_URL } from '~/components/shmoney/constants';
+import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
 import { DownloadButton } from '~/components/shmoney/DownloadButton';
 import { GitHubIcon } from '~/components/shmoney/GitHubIcon';
@@ -87,19 +88,19 @@ function ShmoneyPage() {
 					<div className="flex items-center gap-3">
 						<Logo />
 						<SlashNav className="text-xl font-medium">
-							<a href="/">rafe</a>
+							<Link href="/">rafe</Link>
 							<Wordmark className="font-medium" />
 						</SlashNav>
 					</div>
-					<a
+					<Link
 						href={GITHUB_URL}
 						target="_blank"
 						rel="noreferrer"
-						className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+						className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
 					>
 						<GitHubIcon className="size-4" />
 						GitHub
-					</a>
+					</Link>
 				</header>
 
 				<section className="relative pt-20 sm:pt-24">
@@ -118,9 +119,9 @@ function ShmoneyPage() {
 					<div className="mt-8 flex flex-wrap items-center gap-3">
 						<DownloadButton>Download for free</DownloadButton>
 						<Button asChild variant="outline" size="lg" className="px-4">
-							<a href={GITHUB_URL} target="_blank" rel="noreferrer">
+							<Link plain href={GITHUB_URL} target="_blank" rel="noreferrer">
 								View the source
-							</a>
+							</Link>
 						</Button>
 					</div>
 					<p className="mt-4 text-xs text-muted-foreground">
@@ -188,10 +189,10 @@ function ShmoneyPage() {
 					<div className="flex flex-wrap items-center justify-center gap-3">
 						<DownloadButton>Download shmoney</DownloadButton>
 						<Button asChild variant="outline" size="lg" className="px-4">
-							<a href={GITHUB_URL} target="_blank" rel="noreferrer">
+							<Link plain href={GITHUB_URL} target="_blank" rel="noreferrer">
 								<GitHubIcon className="size-4" />
 								Star on GitHub
-							</a>
+							</Link>
 						</Button>
 					</div>
 					<p className="text-xs text-muted-foreground">
@@ -206,18 +207,18 @@ function ShmoneyPage() {
 					</span>
 					<p>
 						Built by{' '}
-						<a href="https://rafe.dev" className="text-foreground/80 hover:text-foreground">
+						<Link href="https://rafe.dev" className="text-foreground/80 hover:text-foreground">
 							Rafe Autie
-						</a>
+						</Link>
 					</p>
-					<a
+					<Link
 						href={GITHUB_URL}
 						target="_blank"
 						rel="noreferrer"
 						className="ml-auto hover:text-foreground"
 					>
 						GitHub
-					</a>
+					</Link>
 				</footer>
 			</div>
 		</div>


### PR DESCRIPTION
Every anchor in the app now renders through ~/components/Link, which adds a gentle scale and 1px blur on hover. Pass `plain` to opt out for anchors that are not text links: the development project cards, and the anchors slotted into Button via asChild.