### PR TITLE
Always pass a width to the image transform

### DIFF
--- a/workspaces/web/app/routes/about.tsx
+++ b/workspaces/web/app/routes/about.tsx
@@ -1,7 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
-import { getImageUrl } from '../utils';
+import { getImageUrl, SOCIAL_IMAGE_WIDTH } from '../utils';
+
+// The portrait sits full width of a half-page column; the three below it share
+// a 3-column grid, so each is painted at roughly a third of that.
+const FEATURE_WIDTH = 1600;
+const THUMB_WIDTH = 640;
 
 export const Route = createFileRoute('/about')({
 	head: () => ({
@@ -20,7 +25,7 @@ export const Route = createFileRoute('/about')({
 				content:
 					'Based in California, I am a developer specializing in mobile interfaces and front-end architecture.'
 			},
-			{ property: 'og:image', content: getImageUrl('DSCF0740.JPEG') },
+			{ property: 'og:image', content: getImageUrl('DSCF0740.JPEG', SOCIAL_IMAGE_WIDTH) },
 			{ property: 'twitter:card', content: 'summary_large_image' },
 			{ property: 'twitter:url', content: 'https://rafe.dev/about' },
 			{ property: 'twitter:title', content: 'About | Rafe Autie' },
@@ -29,7 +34,7 @@ export const Route = createFileRoute('/about')({
 				content:
 					'Based in California, I am a developer specializing in mobile interfaces and front-end architecture.'
 			},
-			{ property: 'twitter:image', content: getImageUrl('DSCF0740.JPEG') }
+			{ property: 'twitter:image', content: getImageUrl('DSCF0740.JPEG', SOCIAL_IMAGE_WIDTH) }
 		]
 	}),
 	component: AboutPage
@@ -57,17 +62,27 @@ function AboutPage() {
 				</p>
 			</div>
 			<div className="flex flex-col gap-6">
-				<img src={getImageUrl('DSCF0740.JPEG')} alt="Yosemite Valley" width={6240} height={4160} />
+				<img
+					src={getImageUrl('DSCF0740.JPEG', FEATURE_WIDTH)}
+					alt="Yosemite Valley"
+					width={6240}
+					height={4160}
+				/>
 				<div className="grid grid-cols-3 gap-6">
-					<img src={getImageUrl('DSCF0770.JPEG')} alt="Yosemite Lodge" width={4160} height={6240} />
 					<img
-						src={getImageUrl('DSCF0784.JPEG')}
+						src={getImageUrl('DSCF0770.JPEG', THUMB_WIDTH)}
+						alt="Yosemite Lodge"
+						width={4160}
+						height={6240}
+					/>
+					<img
+						src={getImageUrl('DSCF0784.JPEG', THUMB_WIDTH)}
 						alt="Yosemite Abandoned Gas Station"
 						width={4160}
 						height={6240}
 					/>
 					<img
-						src={getImageUrl('DSCF0754.JPEG')}
+						src={getImageUrl('DSCF0754.JPEG', THUMB_WIDTH)}
 						alt="Half Dome and a Plane"
 						width={4160}
 						height={6240}

--- a/workspaces/web/app/routes/index.tsx
+++ b/workspaces/web/app/routes/index.tsx
@@ -3,7 +3,11 @@ import { createServerFn } from '@tanstack/react-start';
 import { env } from 'cloudflare:workers';
 import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
-import { getImageUrl } from '../utils';
+import { getImageUrl, SOCIAL_IMAGE_WIDTH } from '../utils';
+
+// The hero is background-size: contain inside a viewport-height box, so it is
+// never painted wider than the viewport. Matches the lightbox ceiling.
+const HERO_WIDTH = 2048;
 
 const getRandomPhoto = createServerFn().handler(async () => {
 	const objectData = await env.PHOTOS.list();
@@ -19,8 +23,13 @@ const getRandomPhoto = createServerFn().handler(async () => {
 export const Route = createFileRoute('/')({
 	loader: () => getRandomPhoto(),
 	head: ({ loaderData }) => {
-		const img = loaderData?.key ? getImageUrl(loaderData.key) : '';
+		const img = loaderData?.key ? getImageUrl(loaderData.key, SOCIAL_IMAGE_WIDTH) : '';
+		const hero = loaderData?.key ? getImageUrl(loaderData.key, HERO_WIDTH) : '';
 		return {
+			// The hero is a background-image on an inline style, which the preload
+			// scanner does not read: without this hint the fetch waits on CSS and
+			// layout. Same URL as the element, so the two share one request.
+			links: hero ? [{ rel: 'preload', as: 'image', href: hero, fetchPriority: 'high' }] : [],
 			meta: [
 				{ title: 'Rafe Autie | Developer & Photographer' },
 				{
@@ -54,7 +63,7 @@ export const Route = createFileRoute('/')({
 
 function HomePage() {
 	const { key } = Route.useLoaderData();
-	const imageUrl = key ? getImageUrl(key) : '';
+	const imageUrl = key ? getImageUrl(key, HERO_WIDTH) : '';
 
 	return (
 		<div className="flex w-full flex-col items-center justify-center">

--- a/workspaces/web/app/routes/photography.tsx
+++ b/workspaces/web/app/routes/photography.tsx
@@ -4,7 +4,7 @@ import { loadPhotos } from '~/gallery-store';
 import { PhotoGallery } from '~/components/PhotoGallery';
 import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
-import { getImageUrl } from '../utils';
+import { getImageUrl, SOCIAL_IMAGE_WIDTH } from '../utils';
 
 // The gallery measures each photo's real aspect ratio on the client (see
 // PhotoGallery), so the loader hands over keys and metadata but no dimensions.
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/photography')({
 	loader: () => getPhotos(),
 	head: ({ loaderData }) => {
 		const firstPhoto = loaderData?.photos?.[0];
-		const firstImg = firstPhoto ? getImageUrl(firstPhoto.key) : undefined;
+		const firstImg = firstPhoto ? getImageUrl(firstPhoto.key, SOCIAL_IMAGE_WIDTH) : undefined;
 
 		return {
 			meta: [

--- a/workspaces/web/app/utils.ts
+++ b/workspaces/web/app/utils.ts
@@ -1,5 +1,14 @@
-export function getImageUrl(imageKey: string, width?: number) {
-	const options = ['format=auto', 'quality=75'];
-	if (width) options.push(`width=${width}`);
+// Width is not optional in practice. Cloudflare Images refuses to transcode a
+// source above its size ceiling, and rather than erroring it passes the
+// original bytes through: `format=auto` and `quality` both become no-ops and
+// the response carries `warning: cf-images 299 "image too large for AVIF"`.
+// The camera originals in R2 are all over that ceiling, so an uncapped call
+// ships the full multi-megabyte JPEG. Every call site must pass a width.
+export function getImageUrl(imageKey: string, width: number) {
+	const options = ['format=auto', 'quality=75', `width=${width}`];
 	return `https://images.rafe.dev/cdn-cgi/image/${options.join(',')}/${imageKey}`;
 }
+
+// Social scrapers render cards at roughly 1200px wide, and several enforce a
+// payload limit well under the size of an untransformed original.
+export const SOCIAL_IMAGE_WIDTH = 1200;


### PR DESCRIPTION
`getImageUrl` treated `width` as optional, and the home page, the about page and three social cards all left it off.

Cloudflare Images will not transcode a source above its size ceiling, and instead of failing it passes the original bytes straight through — so `format=auto` and `quality=75` were both silently discarded. The camera originals in R2 are all over that ceiling.

The home page hero was serving a **3.9 MB JPEG**, confirmed by the response header:

```
content-type: image/jpeg
content-length: 3884891
warning: cf-images 299 "image too large for AVIF"
```

That accounts for the bulk of a 1.4s first paint.

## Changes

`width` is now a required parameter, so the type checker catches an omission. Every call site is sized to what it actually paints:

| Where | Was | Now |
|---|---|---|
| Home hero | 3.9 MB JPEG | 878 KB WebP (w=2048) |
| About feature | ~4 MB JPEG | 126 KB AVIF (w=1600) |
| About thumbnails (x3) | ~4 MB JPEG each | 137 / 111 / 26 KB AVIF (w=640) |
| Social cards | untransformed original | 58 KB AVIF (w=1200) |

The about thumbnails were the worst case: full 4160x6240 downloads to fill a third of a column.

Social cards were handing scrapers the untransformed original, over the payload limit some platforms enforce.

Also preloads the hero — it is a `background-image` on an inline style, so the preload scanner never sees it and the fetch waits on CSS and layout.

## Verification

- `tsc --noEmit` clean
- `vitest` 7/7 passing
- Sizes above measured against the live CDN

## Follow-ups (not in this PR)

- **Hero width sits above the AVIF cutoff.** Cloudflare skips AVIF over ~3 MP of output. At w=1280 the hero is 263 KB AVIF; at w=2048 it is 878 KB WebP. Kept 2048 to match the existing lightbox ceiling, but 1280 is a 3.3x further cut if the softness on high-DPI displays is acceptable.
- **The hero is a different random photo per request**, so each key is its own cache entry and a visitor who draws a cold one still pays the transform. Sizing does not address that.
- **`prettier --check .` fails repo-wide and predates this branch** — clean `main` fails on 52 files, this branch on 48. Left alone to keep the diff readable.