### PR TITLE
Serve the hero at a size the device can actually paint

### DIFF
--- a/workspaces/web/app/routes/index.tsx
+++ b/workspaces/web/app/routes/index.tsx
@@ -3,33 +3,46 @@ import { createServerFn } from '@tanstack/react-start';
 import { env } from 'cloudflare:workers';
 import { Link } from '~/components/Link';
 import { SlashNav } from '~/components/SlashNav';
-import { getImageUrl, SOCIAL_IMAGE_WIDTH } from '../utils';
+import { AVIF_CEILING_WIDTH, buildSrcSet, getImageUrl, SOCIAL_IMAGE_WIDTH } from '../utils';
 
-// The hero is background-size: contain inside a viewport-height box, so it is
-// never painted wider than the viewport. Matches the lightbox ceiling.
-const HERO_WIDTH = 2048;
+// The hero is object-contain inside a viewport box, so a phone paints it at a
+// fraction of the width a desktop does. Serving one size to both meant mobile
+// downloading several times what it could display. Topping out at the AVIF
+// ceiling keeps every candidate on the cheap side of the codec cliff.
+const HERO_WIDTHS = [640, 1024, AVIF_CEILING_WIDTH];
+// Contained, so the painted width never exceeds the viewport. An upper bound is
+// the best that can be stated here: the real width depends on each photo's
+// aspect ratio, which is not known until the pixels land.
+const HERO_SIZES = '100vw';
+
+// The bucket holds more than photographs: gallery.json, the manifest the
+// photography route reads, sits alongside them. Handing that key to the image
+// transform returns a 415 and the hero renders blank, so drawing is restricted
+// to things that are actually images.
+const PHOTO_KEY = /\.(jpe?g|png|webp|avif)$/i;
 
 const getRandomPhoto = createServerFn().handler(async () => {
 	const objectData = await env.PHOTOS.list();
+	const photos = objectData?.objects?.filter(({ key }) => PHOTO_KEY.test(key)) ?? [];
 
-	if (!objectData?.objects?.length) {
+	if (!photos.length) {
 		return { key: '' };
 	}
 
-	const randomIndex = Math.floor(Math.random() * objectData.objects.length);
-	return { key: objectData.objects[randomIndex]?.key ?? '' };
+	const randomIndex = Math.floor(Math.random() * photos.length);
+	return { key: photos[randomIndex]?.key ?? '' };
 });
 
 export const Route = createFileRoute('/')({
 	loader: () => getRandomPhoto(),
 	head: ({ loaderData }) => {
 		const img = loaderData?.key ? getImageUrl(loaderData.key, SOCIAL_IMAGE_WIDTH) : '';
-		const hero = loaderData?.key ? getImageUrl(loaderData.key, HERO_WIDTH) : '';
 		return {
-			// The hero is a background-image on an inline style, which the preload
-			// scanner does not read: without this hint the fetch waits on CSS and
-			// layout. Same URL as the element, so the two share one request.
-			links: hero ? [{ rel: 'preload', as: 'image', href: hero, fetchPriority: 'high' }] : [],
+			// No hand-written preload for the hero. It is a real <img> in the
+			// server-rendered markup, and React emits a matching rel=preload for it
+			// automatically because of fetchPriority="high" — one that restates the
+			// srcset, so it cannot drift out of sync with the element the way a
+			// hand-maintained hint would.
 			meta: [
 				{ title: 'Rafe Autie | Developer & Photographer' },
 				{
@@ -63,25 +76,35 @@ export const Route = createFileRoute('/')({
 
 function HomePage() {
 	const { key } = Route.useLoaderData();
-	const imageUrl = key ? getImageUrl(key, HERO_WIDTH) : '';
 
 	return (
 		<div className="flex w-full flex-col items-center justify-center">
-			<div
-				className="flex h-dvh w-full flex-col items-center justify-center p-10 text-[clamp(1rem,2.5vmin,10rem)] font-medium text-background transition-colors duration-500 sm:p-15 smh:text-background/0"
-				style={{
-					backgroundImage: `url('${imageUrl}')`,
-					backgroundSize: 'contain',
-					backgroundPosition: 'center',
-					backgroundRepeat: 'no-repeat',
-					backgroundOrigin: 'content-box'
-				}}
-			>
-				<SlashNav separatorClassName="text-inherit opacity-60">
-					<Link href="/about">rafe</Link>
-					<Link href="/photography">photography</Link>
-					<Link href="/development">development</Link>
-				</SlashNav>
+			{/* The padding is what the photo is contained within, so it sits on this
+			    element and the image fills what is left. This is the content box the
+			    old background-origin: content-box was measuring against. */}
+			<div className="relative h-dvh w-full p-10 sm:p-15">
+				{key && (
+					<img
+						src={getImageUrl(key, AVIF_CEILING_WIDTH)}
+						srcSet={buildSrcSet(key, HERO_WIDTHS)}
+						sizes={HERO_SIZES}
+						// Decorative: the photo rotates per request and carries no
+						// caption here, and the nav below is the page's actual content.
+						alt=""
+						fetchPriority="high"
+						decoding="async"
+						className="h-full w-full object-contain"
+					/>
+				)}
+				{/* Overlaid rather than a sibling in flow, so the nav stays centred on
+				    the viewport whether or not a photo loaded. */}
+				<div className="absolute inset-0 flex flex-col items-center justify-center text-[clamp(1rem,2.5vmin,10rem)] font-medium text-background transition-colors duration-500 smh:text-background/0">
+					<SlashNav separatorClassName="text-inherit opacity-60">
+						<Link href="/about">rafe</Link>
+						<Link href="/photography">photography</Link>
+						<Link href="/development">development</Link>
+					</SlashNav>
+				</div>
 			</div>
 		</div>
 	);

--- a/workspaces/web/app/utils.ts
+++ b/workspaces/web/app/utils.ts
@@ -9,6 +9,16 @@ export function getImageUrl(imageKey: string, width: number) {
 	return `https://images.rafe.dev/cdn-cgi/image/${options.join(',')}/${imageKey}`;
 }
 
+export function buildSrcSet(imageKey: string, widths: number[]) {
+	return widths.map((width) => `${getImageUrl(imageKey, width)} ${width}w`).join(', ');
+}
+
 // Social scrapers render cards at roughly 1200px wide, and several enforce a
 // payload limit well under the size of an untransformed original.
 export const SOCIAL_IMAGE_WIDTH = 1200;
+
+// Above roughly 3MP of output Cloudflare stops encoding AVIF and falls back to
+// WebP, which costs about 3x the bytes for the same photo. Measured across the
+// bucket: every photo is AVIF at 1280 and WebP at 2048. Treat this as a ceiling
+// for anything on a critical path.
+export const AVIF_CEILING_WIDTH = 1280;


### PR DESCRIPTION
Follow-up to #28, driven by Lighthouse measurements.

## Why

Five Lighthouse runs on the current production code scored 73-84, with LCP swinging between 4.1s and 10.7s. The variance was not measurement noise — it tracked which photo the randomiser drew:

| Photo | Hero | LCP | Perf |
|---|---|---|---|
| DSCF0740 | 265 KB | 4.1 s | 84 |
| DSCF0644 | 278 KB | 4.1 s | 84 |
| DSCF1154 | 705 KB | 6.2 s | 75 |
| DSCF0774 | 723 KB | 6.3 s | 75 |
| DSCF0784 | 1556 KB | 10.7 s | 73 |

FCP stayed flat (2.05-2.23s) across all five, so the rest of the page is stable. LCP is 25% of the performance score and was scoring 47.

## Changes

**Responsive hero.** One 2048px image went to every device. A phone contains that into ~960 device pixels. The srcset now offers 640/1024/1280 — mobile takes 1024, desktop 1280.

**Capped at the AVIF ceiling.** Above ~3MP of output Cloudflare stops encoding AVIF and falls back to WebP at ~3x the bytes. Every photo in the bucket is AVIF at 1280 and WebP at 2048, so every candidate now stays on the cheap side.

**background-image -> `<img>`.** Required for srcset. The padded container is now the box the photo is contained within, matching what `background-origin: content-box` did. The nav moved to an overlay so it stays centred when no photo loads. Verified by screenshot at 1280x800 and 412x823 against production — framing and nav position are unchanged.

**Removed the hand-written preload.** A server-rendered `<img>` is already visible to the preload scanner, and React emits a matching hint from `fetchPriority="high"` that restates the srcset, so it cannot desync from the element.

## Bug fix (pre-existing, unrelated to perf)

`PHOTOS.list()` returns every object in the bucket, including `gallery.json` — the manifest the photography route reads. When the randomiser drew it, the image transform returned **415 Unsupported Media Type** and the hero rendered blank. Roughly 1 load in 15. Drawing is now restricted to image extensions.

## Verification

- `tsc --noEmit` clean, `vitest` 7/7
- Screenshots compared against production at desktop and mobile viewports
- Lighthouse re-run pending post-deploy